### PR TITLE
Wordwrap program items

### DIFF
--- a/lib/modules/screens/programscreen.dart
+++ b/lib/modules/screens/programscreen.dart
@@ -112,10 +112,13 @@ class _ProgramscreenState extends State<Programscreen> {
                             const Padding(padding: EdgeInsets.only(left: 20)),
 
                             //what
-                            Text(
-                              activityMap[item.activity]!.daTitle,
+                            Flexible(
+                                child: Text(
+                              context.locale.toString() == 'en'
+                                  ? activityMap[item.activity]!.enTitle
+                                  : activityMap[item.activity]!.daTitle,
                               style: const TextStyle(fontSize: 18),
-                            ),
+                            )),
                           ],
                         ),
                         const Padding(padding: EdgeInsets.only(bottom: 10))


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22421190/219973953-9aff5611-42ce-4613-8ef2-110104c1a49a.png)

Make it possible for the Program page to show items that have long names, on multiple lines